### PR TITLE
Add default value to click.option refresh_interval help text

### DIFF
--- a/rqmonitor/cli.py
+++ b/rqmonitor/cli.py
@@ -206,7 +206,7 @@ def check_url(url, decode_components=False):
     "refresh_interval",
     default=RQ_MONITOR_REFRESH_INTERVAL,
     type=int,
-    help="Refresh interval in ms",
+    help="Refresh interval in ms. Default: 2000",
 )
 @click.option(
     "--extra-path",


### PR DESCRIPTION
Added the default value of `2000` from `rqmonitor/defaults.py` to the `help` text for `refresh_interval`.