### PR TITLE
Fix exception when worker hostname is not defined

### DIFF
--- a/rqmonitor/bp.py
+++ b/rqmonitor/bp.py
@@ -159,6 +159,8 @@ def list_workers_api():
             host_ip_using_name = socket.gethostbyname(worker.hostname)
         except socket.gaierror as addr_error:
             pass
+        except TypeError as e:
+            pass
 
         rq_workers.append(
             {


### PR DESCRIPTION
# Previous

When a Worker has not defined the attribute hostname, it raise an exception and the list of workers is not showed

![image](https://user-images.githubusercontent.com/26488435/98239275-f9532380-1f67-11eb-9ddb-e882f7d70606.png)

# After

The list of Workers appears and the field hostname in workers without this attributed, is showed blank

![image](https://user-images.githubusercontent.com/26488435/98239480-4df69e80-1f68-11eb-9b66-9957a077c137.png)

