### PR TITLE
Justify dashboard header with space in between

### DIFF
--- a/rqmonitor/static/assets/libs/css/style.css
+++ b/rqmonitor/static/assets/libs/css/style.css
@@ -383,6 +383,8 @@ html body .display-7 {
   box-shadow: 0px 0px 28px 0px rgba(82, 63, 105, 0.13);
   -webkit-transition: all 0.3s ease;
   min-height: 60px;
+  display: flex;
+  justify-content: space-between;
 }
 
 .navbar-brand {


### PR DESCRIPTION
As requested in issue #4.
Before:
![navbar_before](https://user-images.githubusercontent.com/1123248/192146319-206e4708-ad04-4c70-a71f-22144e16f79e.png)

After:
![navbar_after](https://user-images.githubusercontent.com/1123248/192146331-bc11c447-9f45-4336-b889-c4d99b34194c.png)
